### PR TITLE
Add Comprehensive API Documentation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dev = [
 
 [tool.ruff.lint]
 select = ["ALL"]
-ignore = ["COM812", "D"]
+ignore = ["COM812"]
 
 [tool.ruff.lint.per-file-ignores]
 "__main__.py" = ["T201"]

--- a/src/piper_kit/__init__.py
+++ b/src/piper_kit/__init__.py
@@ -1,3 +1,19 @@
+"""PiPER Kit - SDK and CLI tools for AgileX PiPER robotic arm.
+
+This package provides Python bindings for controlling the AgileX PiPER robotic arm
+via CAN bus interface using the python-can library.
+
+Example:
+    Basic usage of the PiperInterface:
+
+    >>> from piper_kit import PiperInterface
+    >>> with PiperInterface('can0') as piper:
+    ...     piper.enable_all_joints()
+    ...     piper.set_motion_control_b("joint", 20)
+    ...     piper.set_joint_control(0, 0, 0, 0, 0, 0)
+
+"""
+
 from .interface import PiperInterface
 
 __all__ = ["PiperInterface"]

--- a/src/piper_kit/_cli/disable.py
+++ b/src/piper_kit/_cli/disable.py
@@ -1,3 +1,5 @@
+"""CLI command to disable the PiPER robotic arm."""
+
 import argparse
 import time
 
@@ -7,6 +9,12 @@ JOINT_TOLERANCE = 1000
 
 
 def command_disable(args: argparse.Namespace) -> None:
+    """Move PiPER arm to safe position and disable all joints.
+
+    Args:
+        args: Command line arguments containing CAN interface
+
+    """
     with PiperInterface(args.can_interface) as piper:
         piper.set_motion_control_b("joint", 20)
         time.sleep(0.1)

--- a/src/piper_kit/_cli/enable.py
+++ b/src/piper_kit/_cli/enable.py
@@ -1,3 +1,5 @@
+"""CLI command to enable the PiPER robotic arm."""
+
 import argparse
 import time
 
@@ -5,6 +7,12 @@ from piper_kit import PiperInterface
 
 
 def command_enable(args: argparse.Namespace) -> None:
+    """Enable PiPER arm and move to home position.
+
+    Args:
+        args: Command line arguments containing CAN interface
+
+    """
     with PiperInterface(args.can_interface) as piper:
         piper.enable_all_joints()
 

--- a/src/piper_kit/_cli/main.py
+++ b/src/piper_kit/_cli/main.py
@@ -1,3 +1,5 @@
+"""Main CLI entry point for PiPER robotic arm control commands."""
+
 import argparse
 
 from .disable import command_disable
@@ -5,6 +7,7 @@ from .enable import command_enable
 
 
 def main() -> None:
+    """Set up argument parsing and execute commands."""
     parser = argparse.ArgumentParser(prog="piper")
     parser.add_argument("-v", "--version", action="version", version="0.1.0")
     subparsers = parser.add_subparsers(required=True)

--- a/src/piper_kit/interface.py
+++ b/src/piper_kit/interface.py
@@ -1,3 +1,5 @@
+"""PiPER Interface module for robotic arm control via CAN bus."""
+
 from types import TracebackType
 from typing import Self
 
@@ -19,10 +21,22 @@ from .messages import (
 
 
 class PiperInterface:
+    """Interface for controlling the AgileX PiPER robotic arm via CAN bus.
+
+    This class provides methods for controlling joint positions, enabling/disabling
+    joints, and reading feedback from the robotic arm through the CAN bus interface.
+
+    Args:
+        can_iface: CAN interface name (e.g., 'can0')
+
+    """
+
     def __init__(self, can_iface: str) -> None:
+        """Initialize PiperInterface with CAN interface."""
         self.bus = can.Bus(channel=can_iface, interface="socketcan")
 
-    def __enter__(self) -> int:
+    def __enter__(self) -> Self:
+        """Enter context manager."""
         return self
 
     def __exit__(
@@ -30,7 +44,8 @@ class PiperInterface:
         _exc_type: type[BaseException] | None,
         _exc_val: BaseException | None,
         _exc_tb: TracebackType | None,
-    ) -> Self:
+    ) -> None:
+        """Exit context manager and shutdown CAN bus."""
         self.bus.shutdown()
 
     def set_motion_control_b(
@@ -40,15 +55,44 @@ class PiperInterface:
         *,
         control_mode: MotionControlBMessage.ControlMode = "can",
     ) -> None:
+        """Set motion control parameters for the robotic arm.
+
+        Args:
+            move_mode: Motion control mode ('joint' or other modes)
+            move_speed_rate: Speed rate for movement (0-100)
+            control_mode: Control mode ('can' by default)
+
+        """
         self.bus.send(MotionControlBMessage(control_mode, move_mode, move_speed_rate))
 
     def set_joint_control_12(self, joint_1: int, joint_2: int) -> None:
+        """Set position control for joints 1 and 2.
+
+        Args:
+            joint_1: Target position for joint 1
+            joint_2: Target position for joint 2
+
+        """
         self.bus.send(JointControl12Message(joint_1, joint_2))
 
     def set_joint_control_34(self, joint_3: int, joint_4: int) -> None:
+        """Set position control for joints 3 and 4.
+
+        Args:
+            joint_3: Target position for joint 3
+            joint_4: Target position for joint 4
+
+        """
         self.bus.send(JointControl34Message(joint_3, joint_4))
 
     def set_joint_control_56(self, joint_5: int, joint_6: int) -> None:
+        """Set position control for joints 5 and 6.
+
+        Args:
+            joint_5: Target position for joint 5
+            joint_6: Target position for joint 6
+
+        """
         self.bus.send(JointControl56Message(joint_5, joint_6))
 
     def set_joint_control(  # noqa: PLR0913
@@ -60,6 +104,17 @@ class PiperInterface:
         joint_5: int,
         joint_6: int,
     ) -> None:
+        """Set position control for all 6 joints simultaneously.
+
+        Args:
+            joint_1: Target position for joint 1
+            joint_2: Target position for joint 2
+            joint_3: Target position for joint 3
+            joint_4: Target position for joint 4
+            joint_5: Target position for joint 5
+            joint_6: Target position for joint 6
+
+        """
         self.set_joint_control_12(joint_1, joint_2)
         self.set_joint_control_34(joint_3, joint_4)
         self.set_joint_control_56(joint_5, joint_6)
@@ -67,18 +122,44 @@ class PiperInterface:
     def enable_joint(
         self, joint_id: EnableJointMessage.JointId, *, enable: bool = True
     ) -> None:
+        """Enable or disable a specific joint.
+
+        Args:
+            joint_id: Joint ID (1-6) or 7 for all joints
+            enable: True to enable, False to disable
+
+        """
         self.bus.send(EnableJointMessage(joint_id, enable=enable))
 
     def disable_joint(self, joint_id: EnableJointMessage.JointId) -> None:
+        """Disable a specific joint.
+
+        Args:
+            joint_id: Joint ID (1-6) or 7 for all joints
+
+        """
         self.enable_joint(joint_id, enable=False)
 
     def enable_all_joints(self, *, enable: bool = True) -> None:
+        """Enable or disable all joints simultaneously.
+
+        Args:
+            enable: True to enable, False to disable
+
+        """
         self.enable_joint(7, enable=enable)
 
     def disable_all_joints(self) -> None:
+        """Disable all joints simultaneously."""
         self.enable_all_joints(enable=False)
 
     def read_message(self) -> ReceiveMessage:
+        """Read a single message from the CAN bus.
+
+        Returns:
+            Parsed message object (JointFeedback, MotorInfo, or Unknown)
+
+        """
         msg = self.bus.recv()
         match msg.arbitration_id:
             case JointFeedback12Message.ID:
@@ -99,6 +180,14 @@ class PiperInterface:
                 return UnknownMessage(msg)
 
     def read_all_joint_feedbacks(self) -> list[int]:
+        """Read current position feedback from all 6 joints.
+
+        Blocks until feedback is received from all joints.
+
+        Returns:
+            List of 6 joint positions [joint1, joint2, joint3, joint4, joint5, joint6]
+
+        """
         feedbacks = [None] * 6
         while any(f is None for f in feedbacks):
             match self.read_message():
@@ -117,6 +206,14 @@ class PiperInterface:
         return feedbacks
 
     def read_all_motor_info_bs(self) -> list[MotorInfoBMessage]:
+        """Read motor information from all 6 joints.
+
+        Blocks until motor info is received from all joints.
+
+        Returns:
+            List of 6 MotorInfoBMessage objects containing status and diagnostic info
+
+        """
         infos = [None] * 6
         while any(i is None for i in infos):
             match self.read_message():

--- a/src/piper_kit/messages/__init__.py
+++ b/src/piper_kit/messages/__init__.py
@@ -1,3 +1,9 @@
+"""CAN message definitions for PiPER robotic arm communication.
+
+This module contains message classes for communicating with the PiPER arm via CAN bus.
+Messages are organized into transmit (commands sent to arm) and receive (feedback).
+"""
+
 from .receive import (
     JointFeedback12Message,
     JointFeedback34Message,

--- a/src/piper_kit/messages/receive/__init__.py
+++ b/src/piper_kit/messages/receive/__init__.py
@@ -1,3 +1,5 @@
+"""Receive message classes for reading feedback from the PiPER arm."""
+
 from .joint_feedback import (
     JointFeedback12Message,
     JointFeedback34Message,

--- a/src/piper_kit/messages/receive/joint_feedback.py
+++ b/src/piper_kit/messages/receive/joint_feedback.py
@@ -1,28 +1,54 @@
+"""Joint feedback messages from the PiPER arm."""
+
 import can
 
 from .receive import ReceiveMessage
 
 
 class JointFeedback12Message(ReceiveMessage):
+    """Joint feedback message for joints 1 and 2."""
+
     ID = 0x2A5
 
     def __init__(self, msg: can.Message) -> None:
+        """Parse joint feedback message for joints 1 and 2.
+
+        Args:
+            msg: CAN message containing joint position data
+
+        """
         self.joint_1 = int.from_bytes(msg.data[0:4], signed=True)
         self.joint_2 = int.from_bytes(msg.data[4:8], signed=True)
 
 
 class JointFeedback34Message(ReceiveMessage):
+    """Joint feedback message for joints 3 and 4."""
+
     ID = 0x2A6
 
     def __init__(self, msg: can.Message) -> None:
+        """Parse joint feedback message for joints 3 and 4.
+
+        Args:
+            msg: CAN message containing joint position data
+
+        """
         self.joint_3 = int.from_bytes(msg.data[0:4], signed=True)
         self.joint_4 = int.from_bytes(msg.data[4:8], signed=True)
 
 
 class JointFeedback56Message(ReceiveMessage):
+    """Joint feedback message for joints 5 and 6."""
+
     ID = 0x2A7
 
     def __init__(self, msg: can.Message) -> None:
+        """Parse joint feedback message for joints 5 and 6.
+
+        Args:
+            msg: CAN message containing joint position data
+
+        """
         self.joint_5 = int.from_bytes(msg.data[0:4], signed=True)
         self.joint_6 = int.from_bytes(msg.data[4:8], signed=True)
 

--- a/src/piper_kit/messages/receive/motor_info_b.py
+++ b/src/piper_kit/messages/receive/motor_info_b.py
@@ -1,9 +1,13 @@
+"""Motor information messages from the PiPER arm."""
+
 import can
 
 from .receive import ReceiveMessage
 
 
 class MotorInfoBMessage(ReceiveMessage):
+    """Motor information message containing status and diagnostic data."""
+
     ID0 = 0x260
     ID1 = 0x261
     ID2 = 0x262
@@ -13,7 +17,15 @@ class MotorInfoBMessage(ReceiveMessage):
     ID6 = 0x266
 
     class DriverStatus:
+        """Driver status information parsed from status byte."""
+
         def __init__(self, code: int) -> None:
+            """Parse driver status from status code byte.
+
+            Args:
+                code: Status code byte containing bit flags
+
+            """
             self.code = code
             self.low_voltage = bool(code & 1)
             self.motor_overheating = bool(code & 2)
@@ -25,6 +37,12 @@ class MotorInfoBMessage(ReceiveMessage):
             self.stalling_triggered = bool(code & 128)
 
     def __init__(self, msg: can.Message) -> None:
+        """Parse motor information from CAN message.
+
+        Args:
+            msg: CAN message containing motor diagnostic data
+
+        """
         self.motor_id = msg.arbitration_id - MotorInfoBMessage.ID0
         self.bus_voltage = int.from_bytes(msg.data[0:2])
         self.driver_temp = int.from_bytes(msg.data[2:4], signed=True)

--- a/src/piper_kit/messages/receive/receive.py
+++ b/src/piper_kit/messages/receive/receive.py
@@ -1,5 +1,8 @@
+"""Base class for CAN messages received from the PiPER arm."""
+
+
 class ReceiveMessage:
-    pass
+    """Base class for CAN messages received from the PiPER robotic arm."""
 
 
 __all__ = ["ReceiveMessage"]

--- a/src/piper_kit/messages/receive/unknown.py
+++ b/src/piper_kit/messages/receive/unknown.py
@@ -1,10 +1,20 @@
+"""Unknown message handling for unrecognized CAN messages."""
+
 import can
 
 from .receive import ReceiveMessage
 
 
 class UnknownMessage(ReceiveMessage):
+    """Container for unrecognized CAN messages."""
+
     def __init__(self, msg: can.Message) -> None:
+        """Store unknown CAN message data.
+
+        Args:
+            msg: Unrecognized CAN message
+
+        """
         self.arbitration_id = msg.arbitration_id
         self.data = msg.data
 

--- a/src/piper_kit/messages/transmit/__init__.py
+++ b/src/piper_kit/messages/transmit/__init__.py
@@ -1,3 +1,5 @@
+"""Transmit message classes for sending commands to the PiPER arm."""
+
 from .enable_joint import EnableJointMessage
 from .joint_control import (
     JointControl12Message,

--- a/src/piper_kit/messages/transmit/enable_joint.py
+++ b/src/piper_kit/messages/transmit/enable_joint.py
@@ -1,9 +1,13 @@
+"""Joint enable/disable messages for motor control."""
+
 from typing import Literal
 
 from .transmit import TransmitMessage
 
 
 class EnableJointMessage(TransmitMessage):
+    """Message to enable or disable individual joints or all joints."""
+
     ID = 0x471
 
     MIN_JOINT_ID = 1
@@ -12,10 +16,28 @@ class EnableJointMessage(TransmitMessage):
     JointId = Literal[1, 2, 3, 4, 5, 6, 7]
 
     class InvalidJointIdError(ValueError):
+        """Raised when an invalid joint ID is provided."""
+
         def __init__(self, joint_id: any) -> None:
+            """Initialize with invalid joint ID.
+
+            Args:
+                joint_id: The invalid joint ID that was provided
+
+            """
             super().__init__(f"Invalid joint ID: {joint_id!r}")
 
     def __init__(self, joint_id: JointId, *, enable: bool = True) -> None:
+        """Create joint enable/disable message.
+
+        Args:
+            joint_id: Joint ID (1-6 for individual joints, 7 for all joints)
+            enable: True to enable, False to disable
+
+        Raises:
+            InvalidJointIdError: If joint_id is not in range 1-7
+
+        """
         if not self.MIN_JOINT_ID <= joint_id <= self.MAX_JOINT_ID:
             raise self.InvalidJointIdError(joint_id)
 

--- a/src/piper_kit/messages/transmit/joint_control.py
+++ b/src/piper_kit/messages/transmit/joint_control.py
@@ -1,10 +1,21 @@
+"""Joint control messages for commanding joint positions."""
+
 from .transmit import TransmitMessage
 
 
 class JointControl12Message(TransmitMessage):
+    """Joint control message for joints 1 and 2."""
+
     ID = 0x155
 
     def __init__(self, joint_1: int, joint_2: int) -> None:
+        """Create joint control message for joints 1 and 2.
+
+        Args:
+            joint_1: Target position for joint 1
+            joint_2: Target position for joint 2
+
+        """
         super().__init__(
             self.ID,
             *joint_1.to_bytes(4, signed=True),
@@ -13,9 +24,18 @@ class JointControl12Message(TransmitMessage):
 
 
 class JointControl34Message(TransmitMessage):
+    """Joint control message for joints 3 and 4."""
+
     ID = 0x156
 
     def __init__(self, joint_3: int, joint_4: int) -> None:
+        """Create joint control message for joints 3 and 4.
+
+        Args:
+            joint_3: Target position for joint 3
+            joint_4: Target position for joint 4
+
+        """
         super().__init__(
             self.ID,
             *joint_3.to_bytes(4, signed=True),
@@ -24,9 +44,18 @@ class JointControl34Message(TransmitMessage):
 
 
 class JointControl56Message(TransmitMessage):
+    """Joint control message for joints 5 and 6."""
+
     ID = 0x157
 
     def __init__(self, joint_5: int, joint_6: int) -> None:
+        """Create joint control message for joints 5 and 6.
+
+        Args:
+            joint_5: Target position for joint 5
+            joint_6: Target position for joint 6
+
+        """
         super().__init__(
             self.ID,
             *joint_5.to_bytes(4, signed=True),

--- a/src/piper_kit/messages/transmit/motion_control_b.py
+++ b/src/piper_kit/messages/transmit/motion_control_b.py
@@ -1,9 +1,13 @@
+"""Motion control messages for setting arm movement parameters."""
+
 from typing import Literal
 
 from .transmit import TransmitMessage
 
 
 class MotionControlBMessage(TransmitMessage):
+    """Message to configure motion control parameters for the robotic arm."""
+
     ID = 0x151
 
     MIN_MOVE_SPEED_RATE = 0
@@ -13,19 +17,55 @@ class MotionControlBMessage(TransmitMessage):
     MoveMode = Literal["position", "joint", "linear", "circular"]
 
     class InvalidControlModeError(ValueError):
+        """Raised when an invalid control mode is provided."""
+
         def __init__(self, mode: any) -> None:
+            """Initialize with invalid control mode.
+
+            Args:
+                mode: The invalid control mode that was provided
+
+            """
             super().__init__(f"Invalid control mode: {mode!r}")
 
     class InvalidMoveModeError(ValueError):
+        """Raised when an invalid move mode is provided."""
+
         def __init__(self, mode: any) -> None:
+            """Initialize with invalid move mode.
+
+            Args:
+                mode: The invalid move mode that was provided
+
+            """
             super().__init__(f"Invalid move mode: {mode!r}")
 
     class InvalidMoveSpeedRateError(ValueError):
+        """Raised when an invalid move speed rate is provided."""
+
         def __init__(self, rate: any) -> None:
+            """Initialize with invalid move speed rate.
+
+            Args:
+                rate: The invalid move speed rate that was provided
+
+            """
             super().__init__(f"Invalid move speed rate: {rate!r}")
 
     @staticmethod
     def get_control_mode_byte(mode: ControlMode) -> int:
+        """Convert control mode to byte value.
+
+        Args:
+            mode: Control mode string
+
+        Returns:
+            Byte value for the control mode
+
+        Raises:
+            InvalidControlModeError: If mode is not valid
+
+        """
         match mode:
             case "standby":
                 return 0x00
@@ -42,6 +82,18 @@ class MotionControlBMessage(TransmitMessage):
 
     @staticmethod
     def get_move_mode_byte(mode: MoveMode) -> int:
+        """Convert move mode to byte value.
+
+        Args:
+            mode: Move mode string
+
+        Returns:
+            Byte value for the move mode
+
+        Raises:
+            InvalidMoveModeError: If mode is not valid
+
+        """
         match mode:
             case "position":
                 return 0x00
@@ -60,6 +112,19 @@ class MotionControlBMessage(TransmitMessage):
         move_mode: MoveMode,
         move_speed_rate: int,
     ) -> None:
+        """Create motion control message.
+
+        Args:
+            control_mode: Control mode ('can', 'standby', etc.)
+            move_mode: Movement mode ('joint', 'position', etc.)
+            move_speed_rate: Speed rate (0-100)
+
+        Raises:
+            InvalidControlModeError: If control_mode is not valid
+            InvalidMoveModeError: If move_mode is not valid
+            InvalidMoveSpeedRateError: If move_speed_rate is not in range 0-100
+
+        """
         if not self.MIN_MOVE_SPEED_RATE <= move_speed_rate <= self.MAX_MOVE_SPEED_RATE:
             raise self.InvalidMoveSpeedRateError(move_speed_rate)
 

--- a/src/piper_kit/messages/transmit/transmit.py
+++ b/src/piper_kit/messages/transmit/transmit.py
@@ -1,7 +1,11 @@
+"""Base class for CAN messages transmitted to the PiPER arm."""
+
 import can
 
 
 class TransmitMessage(can.Message):
+    """Base class for CAN messages sent to the PiPER robotic arm."""
+
     def __init__(  # noqa: PLR0913
         self,
         arbitration_id: int,
@@ -14,6 +18,20 @@ class TransmitMessage(can.Message):
         data_6: int = 0x00,
         data_7: int = 0x00,
     ) -> None:
+        """Initialize CAN message with arbitration ID and data bytes.
+
+        Args:
+            arbitration_id: CAN message ID
+            data_0: Data byte 0 (default: 0x00)
+            data_1: Data byte 1 (default: 0x00)
+            data_2: Data byte 2 (default: 0x00)
+            data_3: Data byte 3 (default: 0x00)
+            data_4: Data byte 4 (default: 0x00)
+            data_5: Data byte 5 (default: 0x00)
+            data_6: Data byte 6 (default: 0x00)
+            data_7: Data byte 7 (default: 0x00)
+
+        """
         super().__init__(
             arbitration_id=arbitration_id,
             data=[data_0, data_1, data_2, data_3, data_4, data_5, data_6, data_7],


### PR DESCRIPTION
This pull request resolves #23 by adding comprehensive [pydoc](https://docs.python.org/3/library/pydoc.html)-style documentation throughout the codebase. It does so by documenting all public classes, methods, and modules including the main `PiperInterface` class, all CAN message classes, and CLI modules. This ensures that developers have clear understanding of the API functionality and enables automatic documentation generation. All linting checks pass with the new documentation following Python docstring standards.