### PR TITLE
Filter Unnecessary Files from Source Distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ dev = [
     "ruff>=0.11.13",
 ]
 
+[tool.hatch.build.targets.sdist]
+include = ["src"]
+
 [tool.ruff.lint]
 select = ["ALL"]
 ignore = ["COM812", "D203", "D213"]


### PR DESCRIPTION
This pull request resolves #35 by configuring the template to include only the `src` directory in the source distribution.
