### PR TITLE
Fix Project Name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Piper Kit
+# PiPER Kit
 
 A Python SDK and CLI toolkit for controlling the [AgileX PiPER](https://global.agilex.ai/products/piper) 6-DOF robotic arm via CAN bus communication.
 


### PR DESCRIPTION
This pull request resolves #38 by correcting the project name from **Piper Kit** to **PiPER Kit** in the `README.md` file.