### PR TITLE
Add Gripper Control When Teleoperating Joints

### DIFF
--- a/src/piper_kit/_cli/teleop/joint.py
+++ b/src/piper_kit/_cli/teleop/joint.py
@@ -16,6 +16,7 @@ class Screen:
         self.exit = False
         self.feedbacks = [0, 0, 0, 0, 0, 0]
         self.positions = [0, 0, 0, 0, 0, 0]
+        self.gripper_position = 0
 
     def __enter__(self) -> Self:
         self._stdscr = curses.initscr()
@@ -38,15 +39,17 @@ class Screen:
         self._stdscr.addstr(8, 2, "Wrist1 (J4):")
         self._stdscr.addstr(9, 2, "Wrist2 (J5):")
         self._stdscr.addstr(10, 2, "Wrist3 (J6):")
+        self._stdscr.addstr(11, 2, "Gripper:")
 
-        self._stdscr.addstr(12, 2, "Keyboard Controls:", curses.A_BOLD)
-        self._stdscr.addstr(13, 4, "Base (J1):     A/D - Rotate left/right")
-        self._stdscr.addstr(14, 4, "Shoulder (J2): W/S - Move up/down")
-        self._stdscr.addstr(15, 4, "Elbow (J3):    I/K - Move up/down")
-        self._stdscr.addstr(16, 4, "Wrist1 (J4):   J/L - Rotate left/right")
-        self._stdscr.addstr(17, 4, "Wrist2 (J5):   Q/E - Rotate left/right")
-        self._stdscr.addstr(18, 4, "Wrist3 (J6):   U/O - Rotate left/right")
-        self._stdscr.addstr(20, 4, "ESC - Exit teleoperation", curses.A_BOLD)
+        self._stdscr.addstr(13, 2, "Keyboard Controls:", curses.A_BOLD)
+        self._stdscr.addstr(14, 4, "Base (J1):     A/D - Rotate left/right")
+        self._stdscr.addstr(15, 4, "Shoulder (J2): W/S - Move up/down")
+        self._stdscr.addstr(16, 4, "Elbow (J3):    I/K - Move up/down")
+        self._stdscr.addstr(17, 4, "Wrist1 (J4):   J/L - Rotate left/right")
+        self._stdscr.addstr(18, 4, "Wrist2 (J5):   Q/E - Rotate left/right")
+        self._stdscr.addstr(19, 4, "Wrist3 (J6):   U/O - Rotate left/right")
+        self._stdscr.addstr(20, 4, "Gripper:       F/H - Open/close")
+        self._stdscr.addstr(22, 4, "ESC - Exit teleoperation", curses.A_BOLD)
 
         self._stdscr.refresh()
 
@@ -89,12 +92,17 @@ class Screen:
                 self.positions[5] -= 5000
             elif key == ord("o"):
                 self.positions[5] += 5000
+            elif key == ord("f"):
+                self.gripper_position += 5000
+            elif key == ord("h"):
+                self.gripper_position -= 5000
 
             for i in range(6):
                 diff = self.positions[i] - self.feedbacks[i]
                 info = f"{self.positions[i]:<12} {self.feedbacks[i]:<12} {diff:<10}"
                 self._stdscr.addstr(5 + i, 18, info)
 
+            self._stdscr.addstr(11, 18, f"{self.gripper_position:<12}")
             self._stdscr.refresh()
 
             time.sleep(1 / 30)
@@ -107,6 +115,7 @@ def command_teleop_joint(args: argparse.Namespace) -> None:
 
             piper.set_motion_control_b("joint", 20)
             piper.set_joint_control(*screen.positions)
+            piper.set_gripper_control(screen.gripper_position)
 
 
 __all__ = ["command_teleop_joint"]

--- a/src/piper_kit/interface.py
+++ b/src/piper_kit/interface.py
@@ -8,6 +8,7 @@ import can
 from .messages import (
     EnableJointMessage,
     GripperControlMessage,
+    GripperFeedbackMessage,
     JointControl12Message,
     JointControl34Message,
     JointControl56Message,
@@ -200,7 +201,8 @@ class PiperInterface:
         """Read a single message from the CAN bus.
 
         Returns:
-            Parsed message object (JointFeedback, MotorInfo, or Unknown)
+            Parsed message object (JointFeedback, GripperFeedback, MotorInfo, or
+            Unknown)
 
         """
         msg = self.bus.recv()
@@ -213,6 +215,9 @@ class PiperInterface:
 
             case JointFeedback56Message.ID:
                 return JointFeedback56Message(msg)
+
+            case GripperFeedbackMessage.ID:
+                return GripperFeedbackMessage(msg)
 
             case _ if (
                 MotorInfoBMessage.ID1 <= msg.arbitration_id <= MotorInfoBMessage.ID6

--- a/src/piper_kit/messages/__init__.py
+++ b/src/piper_kit/messages/__init__.py
@@ -5,6 +5,7 @@ Messages are organized into transmit (commands sent to arm) and receive (feedbac
 """
 
 from .receive import (
+    GripperFeedbackMessage,
     JointFeedback12Message,
     JointFeedback34Message,
     JointFeedback56Message,
@@ -25,6 +26,7 @@ from .transmit import (
 __all__ = [
     "EnableJointMessage",
     "GripperControlMessage",
+    "GripperFeedbackMessage",
     "JointControl12Message",
     "JointControl34Message",
     "JointControl56Message",

--- a/src/piper_kit/messages/receive/__init__.py
+++ b/src/piper_kit/messages/receive/__init__.py
@@ -1,5 +1,6 @@
 """Receive message classes for reading feedback from the PiPER arm."""
 
+from .gripper_feedback import GripperFeedbackMessage
 from .joint_feedback import (
     JointFeedback12Message,
     JointFeedback34Message,
@@ -10,6 +11,7 @@ from .receive import ReceiveMessage
 from .unknown import UnknownMessage
 
 __all__ = [
+    "GripperFeedbackMessage",
     "JointFeedback12Message",
     "JointFeedback34Message",
     "JointFeedback56Message",

--- a/src/piper_kit/messages/receive/gripper_feedback.py
+++ b/src/piper_kit/messages/receive/gripper_feedback.py
@@ -1,0 +1,45 @@
+"""Gripper feedback message implementation."""
+
+import can
+
+from .receive import ReceiveMessage
+
+
+class GripperFeedbackMessage(ReceiveMessage):
+    """CAN message containing gripper position and status feedback."""
+
+    ID = 0x2A8
+
+    class GripperStatus:
+        """Gripper status information parsed from status byte."""
+
+        def __init__(self, code: int) -> None:
+            """Parse gripper status from status code byte.
+
+            Args:
+                code: Status code byte containing bit flags
+
+            """
+            self.code = code
+            self.low_voltage = bool(code & 1)
+            self.motor_overheating = bool(code & 2)
+            self.driver_overcurrent = bool(code & 4)
+            self.driver_overheating = bool(code & 8)
+            self.sensor_error = bool(code & 16)
+            self.driver_error = bool(code & 32)
+            self.driver_enabled = bool(code & 64)
+            self.is_zeroed = bool(code & 128)
+
+    def __init__(self, msg: can.Message) -> None:
+        """Parse gripper feedback from CAN message.
+
+        Args:
+            msg: CAN message containing gripper feedback data
+
+        """
+        self.position = int.from_bytes(msg.data[0:4], signed=True)
+        self.effort = int.from_bytes(msg.data[4:6])
+        self.status = self.GripperStatus(msg.data[6])
+
+
+__all__ = ["GripperFeedbackMessage"]


### PR DESCRIPTION
This pull request resolves #40 by modifying the `piper teleop joint` command to also control the PiPER arm's gripper and display the gripper feedback position. This change also updates the `PiperInterface` class to support parsing the gripper feedback message.
