### PR TITLE
Update Enable Commands to Control Gripper

### DIFF
--- a/src/piper_kit/_cli/disable.py
+++ b/src/piper_kit/_cli/disable.py
@@ -13,6 +13,7 @@ def command_disable(args: argparse.Namespace) -> None:
 
         positions = [0, 0, 0, 0, 17000, 0]
         piper.set_joint_control(*positions)
+        piper.set_gripper_control(90000, 1000)
 
         while True:
             feedbacks = piper.read_all_joint_feedbacks()
@@ -23,6 +24,7 @@ def command_disable(args: argparse.Namespace) -> None:
                 break
 
         piper.disable_all_joints()
+        piper.disable_gripper()
 
 
 __all__ = ["command_disable"]

--- a/src/piper_kit/_cli/enable.py
+++ b/src/piper_kit/_cli/enable.py
@@ -17,6 +17,7 @@ def command_enable(args: argparse.Namespace) -> None:
         time.sleep(0.1)
 
         piper.set_joint_control(0, 0, 0, 0, 0, 0)
+        piper.set_gripper_control(45000, 1000)
 
 
 __all__ = ["command_enable"]

--- a/src/piper_kit/interface.py
+++ b/src/piper_kit/interface.py
@@ -7,6 +7,7 @@ import can
 
 from .messages import (
     EnableJointMessage,
+    GripperControlMessage,
     JointControl12Message,
     JointControl34Message,
     JointControl56Message,
@@ -118,6 +119,48 @@ class PiperInterface:
         self.set_joint_control_12(joint_1, joint_2)
         self.set_joint_control_34(joint_3, joint_4)
         self.set_joint_control_56(joint_5, joint_6)
+
+    def set_gripper_control(
+        self,
+        position: int,
+        effort: int,
+        *,
+        enable: bool = True,
+        clear_error: bool = False,
+        set_zero: bool = False,
+    ) -> None:
+        """Control gripper position and effort.
+
+        Args:
+            position: Target gripper position
+            effort: Effort/force to apply
+            enable: Enable gripper control
+            clear_error: Clear any error state
+            set_zero: Set current position as zero reference
+
+        """
+        self.bus.send(
+            GripperControlMessage(
+                position,
+                effort,
+                enable=enable,
+                clear_error=clear_error,
+                set_zero=set_zero,
+            )
+        )
+
+    def enable_gripper(self, *, enable: bool = True) -> None:
+        """Enable or disable gripper control.
+
+        Args:
+            enable: True to enable, False to disable
+
+        """
+        self.set_gripper_control(0, 0, enable=enable)
+
+    def disable_gripper(self) -> None:
+        """Disable gripper control."""
+        self.enable_gripper(enable=False)
 
     def enable_joint(
         self, joint_id: EnableJointMessage.JointId, *, enable: bool = True

--- a/src/piper_kit/messages/__init__.py
+++ b/src/piper_kit/messages/__init__.py
@@ -14,6 +14,7 @@ from .receive import (
 )
 from .transmit import (
     EnableJointMessage,
+    GripperControlMessage,
     JointControl12Message,
     JointControl34Message,
     JointControl56Message,
@@ -23,6 +24,7 @@ from .transmit import (
 
 __all__ = [
     "EnableJointMessage",
+    "GripperControlMessage",
     "JointControl12Message",
     "JointControl34Message",
     "JointControl56Message",

--- a/src/piper_kit/messages/transmit/__init__.py
+++ b/src/piper_kit/messages/transmit/__init__.py
@@ -1,6 +1,7 @@
 """Transmit message classes for sending commands to the PiPER arm."""
 
 from .enable_joint import EnableJointMessage
+from .gripper_control import GripperControlMessage
 from .joint_control import (
     JointControl12Message,
     JointControl34Message,
@@ -11,6 +12,7 @@ from .transmit import TransmitMessage
 
 __all__ = [
     "EnableJointMessage",
+    "GripperControlMessage",
     "JointControl12Message",
     "JointControl34Message",
     "JointControl56Message",

--- a/src/piper_kit/messages/transmit/gripper_control.py
+++ b/src/piper_kit/messages/transmit/gripper_control.py
@@ -1,0 +1,57 @@
+"""Gripper control message implementation."""
+
+from .transmit import TransmitMessage
+
+
+class GripperControlMessage(TransmitMessage):
+    """CAN message for controlling gripper position and effort."""
+
+    ID = 0x159
+
+    MIN_GRIPPER_EFFORT = 0
+    MAX_GRIPPER_EFFORT = 5000
+
+    class InvalidGripperEffortError(ValueError):
+        """Raised when an invalid gripper effort is provided."""
+
+        def __init__(self, effort: any) -> None:
+            """Initialize with invalid gripper effort.
+
+            Args:
+                effort: The invalid gripper effort that was provided
+
+            """
+            super().__init__(f"Invalid gripper effort: {effort!r}")
+
+    def __init__(
+        self,
+        position: int,
+        effort: int,
+        *,
+        enable: bool = False,
+        clear_error: bool = False,
+        set_zero: bool = False,
+    ) -> None:
+        """Initialize gripper control message.
+
+        Args:
+            position: Target gripper position
+            effort: Effort/force to apply
+            enable: Enable gripper control
+            clear_error: Clear any error state
+            set_zero: Set current position as zero reference
+
+        """
+        if not self.MIN_GRIPPER_EFFORT <= effort <= self.MAX_GRIPPER_EFFORT:
+            raise self.InvalidGripperEffortError(effort)
+
+        super().__init__(
+            self.ID,
+            *position.to_bytes(4, signed=True),
+            *effort.to_bytes(2),
+            (0x01 if enable else 0x00) | (0x02 if clear_error else 0x00),
+            0xAE if set_zero else 0x00,
+        )
+
+
+__all__ = ["GripperControlMessage"]


### PR DESCRIPTION
This pull request resolves #42 by modifying the `piper enable` and `piper disable` commands to also enable and disable the PiPER arm's gripper. This change also updates the `PiperInterface` class by adding methods for controlling the gripper.
