### PR TITLE
Use dprint to Format Source Code

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,8 +18,8 @@ jobs:
       - name: Install Dependencies
         run: uv sync --locked
 
-      - name: Check Format
-        run: uv run ruff format --diff
+      - name: Check Formatting
+        uses: dprint/check@v2.3
 
       - name: Check Lint
         run: uv run ruff check

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ piper disable can1
 from piper_kit import PiperInterface
 
 # Use context manager for proper cleanup
-with PiperInterface('can0') as piper:
+with PiperInterface("can0") as piper:
     # Enable all joints
     piper.enable_all_joints()
 

--- a/dprint.json
+++ b/dprint.json
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    "https://plugins.dprint.dev/json-0.20.0.wasm",
+    "https://plugins.dprint.dev/markdown-0.19.0.wasm",
+    "https://plugins.dprint.dev/toml-0.7.0.wasm",
+    "https://plugins.dprint.dev/ruff-0.4.1.wasm",
+    "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.1.wasm"
+  ]
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -5,7 +5,7 @@ pre-commit:
       run: uv sync
 
     - name: fix formatting
-      run: uv run ruff format
+      run: dprint fmt
 
     - name: fix lint
       run: uv run ruff check --fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,27 +2,27 @@
 name = "piper-kit"
 version = "0.1.0"
 dependencies = [
-    "python-can>=4.5.0",
+  "python-can>=4.5.0",
 ]
 requires-python = ">=3.13"
 authors = [
-    {name = "Alfi Maulana", email = "alfi.maulana.f@gmail.com"},
+  { name = "Alfi Maulana", email = "alfi.maulana.f@gmail.com" },
 ]
 description = "SDK and CLI tools for AgileX PiPER robotic arm"
 readme = "README.md"
 license = "MIT"
 keywords = ["robotics", "can-bus", "agilex", "piper", "robotic-arm", "automation", "sdk", "cli"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
-    "Intended Audience :: Developers",
-    "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
-    "Operating System :: POSIX :: Linux",
-    "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.13",
-    "Topic :: Scientific/Engineering :: Artificial Intelligence",
-    "Topic :: Software Development :: Libraries :: Python Modules",
-    "Topic :: System :: Hardware :: Hardware Drivers",
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "Intended Audience :: Science/Research",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: POSIX :: Linux",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.13",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+  "Topic :: System :: Hardware :: Hardware Drivers",
 ]
 
 [project.scripts]
@@ -38,8 +38,8 @@ build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = [
-    "lefthook>=1.11.14",
-    "ruff>=0.11.13",
+  "lefthook>=1.11.14",
+  "ruff>=0.11.13",
 ]
 
 [tool.hatch.build.targets.sdist]


### PR DESCRIPTION
This pull request resolves #52 by utilizing [dprint](https://dprint.dev/) to format the source code in this project, expanding the formatting to cover all configuration files in addition to the Python source files.
