### PR TITLE
Remove Unused `return self` in `on_enter` Callback

### DIFF
--- a/src/piper_kit/_cli/teleop/end_pose.py
+++ b/src/piper_kit/_cli/teleop/end_pose.py
@@ -1,5 +1,4 @@
 import argparse
-from typing import Self
 
 from cursers import ThreadedApp
 
@@ -22,7 +21,7 @@ class TeleopEndPoseApp(ThreadedApp):
         self.current_gripper = 0
         self.target_gripper = 0
 
-    def on_enter(self) -> Self:
+    def on_enter(self) -> None:
         title = "PiPER End-Effector Pose Teleoperation"
         self.draw_text(0, (55 - len(title)) // 2, title, bold=True)
 
@@ -43,8 +42,6 @@ class TeleopEndPoseApp(ThreadedApp):
         self.draw_text(19, 4, "J/L - Rotate yaw rotation")
         self.draw_text(20, 4, "F/H - Open/close gripper")
         self.draw_text(22, 4, "ESC - Exit teleoperation", bold=True)
-
-        return self
 
     def on_update(self, key: int) -> None:  # noqa: C901, PLR0912
         match chr(key) if key != -1 else None:

--- a/src/piper_kit/_cli/teleop/follow.py
+++ b/src/piper_kit/_cli/teleop/follow.py
@@ -1,5 +1,4 @@
 import argparse
-from typing import Self
 
 from cursers import Thread, ThreadedApp
 
@@ -19,7 +18,7 @@ class TeleopFollowApp(ThreadedApp):
         self.leader_pos = [0, 0, 0, 0, 0, 0, 0]
         self.follower_pos = [0, 0, 0, 0, 0, 0, 0]
 
-    def on_enter(self) -> Self:
+    def on_enter(self) -> None:
         title = "PiPER Leader-Follower Teleoperation"
         self.draw_text(0, (55 - len(title)) // 2, title, bold=True)
 
@@ -38,8 +37,6 @@ class TeleopFollowApp(ThreadedApp):
 
         self.draw_text(13, 2, "Keyboard Controls:", bold=True)
         self.draw_text(14, 4, "ESC - Exit teleoperation", bold=True)
-
-        return self
 
     def on_update(self, key: int) -> None:
         match chr(key) if key != -1 else None:

--- a/src/piper_kit/_cli/teleop/joint.py
+++ b/src/piper_kit/_cli/teleop/joint.py
@@ -1,5 +1,4 @@
 import argparse
-from typing import Self
 
 from cursers import ThreadedApp
 
@@ -19,7 +18,7 @@ class TeleopJointApp(ThreadedApp):
         self.current_pos = [0, 0, 0, 0, 0, 0, 0]
         self.target_pos = [0, 0, 0, 0, 0, 0, 45000]
 
-    def on_enter(self) -> Self:
+    def on_enter(self) -> None:
         title = "PiPER Joint Teleoperation"
         self.draw_text(0, (55 - len(title)) // 2, title, bold=True)
 
@@ -45,8 +44,6 @@ class TeleopJointApp(ThreadedApp):
         self.draw_text(19, 4, "Wrist3 (J6):   U/O - Rotate left/right")
         self.draw_text(20, 4, "Gripper:       F/H - Open/close")
         self.draw_text(22, 4, "ESC - Exit teleoperation", bold=True)
-
-        return self
 
     def on_update(self, key: int) -> None:  # noqa: C901, PLR0912
         match chr(key) if key != -1 else None:


### PR DESCRIPTION
This pull request resolves #58 by removing the unused `return self` in the `on_enter` callbacks.