### PR TITLE
Allow Package to Be Executed as a Module

### DIFF
--- a/src/piper_kit/__main__.py
+++ b/src/piper_kit/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point for running PiPER Kit as a module."""
+
+from ._cli import main
+
+if __name__ == "__main__":
+    main()

--- a/src/piper_kit/_cli/__init__.py
+++ b/src/piper_kit/_cli/__init__.py
@@ -1,0 +1,3 @@
+from .main import main
+
+__all__ = ["main"]

--- a/src/piper_kit/_cli/main.py
+++ b/src/piper_kit/_cli/main.py
@@ -76,5 +76,4 @@ def main() -> None:
     args.func(args)
 
 
-if __name__ == "__main__":
-    main()
+__all__ = ["main"]


### PR DESCRIPTION
This pull request resolves #66 by adding a new `__main__.py` file to allow the package to be executed as a module.