### PR TITLE
Rename Piper Interface Class to Piper

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ piper disable can1
 ### Python SDK
 
 ```python
-from piper_kit import PiperInterface
+from piper_kit import Piper
 
 # Use context manager for proper cleanup
-with PiperInterface("can0") as piper:
+with Piper("can0") as piper:
     # Enable all joints
     piper.enable_all_joints()
 

--- a/src/piper_kit/__init__.py
+++ b/src/piper_kit/__init__.py
@@ -4,10 +4,10 @@ This package provides Python bindings for controlling the AgileX PiPER robotic a
 via CAN bus interface using the python-can library.
 
 Example:
-    Basic usage of the PiperInterface:
+    Basic usage of the Piper:
 
-    >>> from piper_kit import PiperInterface
-    >>> with PiperInterface('can0') as piper:
+    >>> from piper_kit import Piper
+    >>> with Piper('can0') as piper:
     ...     piper.enable_all_joints()
     ...     piper.set_motion_control_b("joint", 20)
     ...     piper.set_joint_control(0, 0, 0, 0, 0, 0)
@@ -40,7 +40,7 @@ from .messages import (
 )
 
 
-class PiperInterface:
+class Piper:
     """Interface for controlling the AgileX PiPER robotic arm via CAN bus.
 
     This class provides methods for controlling joint positions, enabling/disabling
@@ -52,7 +52,7 @@ class PiperInterface:
     """
 
     def __init__(self, can_iface: str) -> None:
-        """Initialize PiperInterface with CAN interface."""
+        """Initialize Piper with CAN interface."""
         self.bus = can.Bus(channel=can_iface, interface="socketcan")
 
     def __enter__(self) -> Self:
@@ -391,4 +391,4 @@ class PiperInterface:
         return feedback
 
 
-__all__ = ["PiperInterface"]
+__all__ = ["Piper"]

--- a/src/piper_kit/_commands/clear.py
+++ b/src/piper_kit/_commands/clear.py
@@ -1,10 +1,10 @@
 import argparse
 
-from piper_kit import PiperInterface
+from piper_kit import Piper
 
 
 def on_command(args: argparse.Namespace) -> None:
-    with PiperInterface(args.can_interface) as piper:
+    with Piper(args.can_interface) as piper:
         piper.set_all_joint_configs(clear_error=True)
 
 

--- a/src/piper_kit/_commands/disable.py
+++ b/src/piper_kit/_commands/disable.py
@@ -1,13 +1,13 @@
 import argparse
 import time
 
-from piper_kit import PiperInterface
+from piper_kit import Piper
 
 JOINT_TOLERANCE = 1000
 
 
 def on_command(args: argparse.Namespace) -> None:
-    with PiperInterface(args.can_interface) as piper:
+    with Piper(args.can_interface) as piper:
         piper.set_motion_control_b("joint", 20)
         time.sleep(0.1)
 

--- a/src/piper_kit/_commands/enable.py
+++ b/src/piper_kit/_commands/enable.py
@@ -1,11 +1,11 @@
 import argparse
 import time
 
-from piper_kit import PiperInterface
+from piper_kit import Piper
 
 
 def on_command(args: argparse.Namespace) -> None:
-    with PiperInterface(args.can_interface) as piper:
+    with Piper(args.can_interface) as piper:
         piper.enable_all_joints()
 
         while True:

--- a/src/piper_kit/_commands/play.py
+++ b/src/piper_kit/_commands/play.py
@@ -4,7 +4,7 @@ import sys
 import time
 from pathlib import Path
 
-from piper_kit import PiperInterface
+from piper_kit import Piper
 
 
 def interpolate(x0: float, y0: float, x1: float, y1: float, x: float) -> float:
@@ -14,7 +14,7 @@ def interpolate(x0: float, y0: float, x1: float, y1: float, x: float) -> float:
 def on_command(args: argparse.Namespace) -> None:
     sys.stdout.write("initializing...\n")
     with (
-        PiperInterface(args.can_interface) as piper,
+        Piper(args.can_interface) as piper,
         Path(args.csv_file).open() as csv_file,
     ):
         reader = csv.reader(csv_file)

--- a/src/piper_kit/_commands/teleop/end_pose.py
+++ b/src/piper_kit/_commands/teleop/end_pose.py
@@ -2,7 +2,7 @@ import argparse
 
 from cursers import ThreadedApp
 
-from piper_kit import PiperInterface
+from piper_kit import Piper
 from piper_kit.messages import GripperFeedbackMessage
 
 
@@ -88,7 +88,7 @@ class TeleopEndPoseApp(ThreadedApp):
 
 
 def on_command(args: argparse.Namespace) -> None:
-    with PiperInterface(args.can_interface) as piper, TeleopEndPoseApp() as app:
+    with Piper(args.can_interface) as piper, TeleopEndPoseApp() as app:
         while app.is_running():
             match piper.read_message():
                 case GripperFeedbackMessage() as msg:

--- a/src/piper_kit/_commands/teleop/follow.py
+++ b/src/piper_kit/_commands/teleop/follow.py
@@ -2,7 +2,7 @@ import argparse
 
 from cursers import Thread, ThreadedApp
 
-from piper_kit import PiperInterface
+from piper_kit import Piper
 from piper_kit.messages import (
     GripperFeedbackMessage,
     JointFeedback12Message,
@@ -53,7 +53,7 @@ class TeleopFollowApp(ThreadedApp):
 
 
 class FollowerThread(Thread):
-    def __init__(self, follower: PiperInterface, app: TeleopFollowApp) -> None:
+    def __init__(self, follower: Piper, app: TeleopFollowApp) -> None:
         super().__init__()
         self._follower = follower
         self._app = app
@@ -79,8 +79,8 @@ class FollowerThread(Thread):
 
 def on_command(args: argparse.Namespace) -> None:
     with (
-        PiperInterface(args.leader_can) as leader,
-        PiperInterface(args.follower_can) as follower,
+        Piper(args.leader_can) as leader,
+        Piper(args.follower_can) as follower,
         TeleopFollowApp() as app,
         FollowerThread(follower, app),
     ):

--- a/src/piper_kit/_commands/teleop/joint.py
+++ b/src/piper_kit/_commands/teleop/joint.py
@@ -2,7 +2,7 @@ import argparse
 
 from cursers import ThreadedApp
 
-from piper_kit import PiperInterface
+from piper_kit import Piper
 from piper_kit.messages import (
     GripperFeedbackMessage,
     JointFeedback12Message,
@@ -88,7 +88,7 @@ class TeleopJointApp(ThreadedApp):
 
 
 def on_command(args: argparse.Namespace) -> None:
-    with PiperInterface(args.can_interface) as piper, TeleopJointApp() as app:
+    with Piper(args.can_interface) as piper, TeleopJointApp() as app:
         while app.is_running():
             match piper.read_message():
                 case JointFeedback12Message() as msg:


### PR DESCRIPTION
This pull request resolves #76 by simply renaming the `PiperInterface` class to `Piper`.